### PR TITLE
feat: allow module imports

### DIFF
--- a/packages/access-control/README.md
+++ b/packages/access-control/README.md
@@ -1,4 +1,4 @@
-### Open API spec to TS
+# Nest ACL
 
 Fork of [nest-access-control](https://github.com/nestjsx/nest-access-control), instead making use of [role-acl](https://github.com/tensult/role-acl).
 It offers a great flexibility on how to build condition to grant or deny access to specific resources and related actions.
@@ -9,7 +9,7 @@ It offers a great flexibility on how to build condition to grant or deny access 
 npm i @nest-toolbox/access-control
 ```
 
-### Example
+## Example
 
 ### Constants
 

--- a/packages/access-control/package.json
+++ b/packages/access-control/package.json
@@ -46,13 +46,13 @@
         "@nestjs/core": "^7.2.0",
         "@types/node": "14.14.22",
         "reflect-metadata": "^0.1.13",
-        "role-acl": "4.5.4",
-        "ts-node": "9.1.1"
+        "role-acl": "4.5.4"
     },
     "devDependencies": {
         "@nestjs/testing": "7.6.9",
         "rimraf": "~3.0.2",
         "rxjs": "6.6.3",
+        "ts-node": "9.1.1",
         "typescript": "4.1.3"
     }
 }

--- a/packages/access-control/src/access-control.module.ts
+++ b/packages/access-control/src/access-control.module.ts
@@ -1,4 +1,4 @@
-import { Abstract, DynamicModule, Global, Module, Type } from '@nestjs/common';
+import { Abstract, DynamicModule, Global, Module, Type, ModuleMetadata, Provider } from '@nestjs/common';
 import { PATH_METADATA } from '@nestjs/common/constants';
 import { ACOptions } from './ac-options.interface';
 import { RULES_BUILDER_TOKEN } from './constants';
@@ -6,48 +6,68 @@ import { GrantsController } from './controller/grants.controller';
 import { RulesBuilder } from './rules-builder.class';
 
 // tslint:disable-next-line: ban-types
-type Injection = (Type<any> | string | symbol | Abstract<any> | Function)[];
+export type Injection = (Type<any> | string | symbol | Abstract<any> | Function)[];
+
+export interface AccessControlOptionsFactory {
+  createAccessControlOptions(rules: RulesBuilder, options?: ACOptions): Promise<RulesBuilder> | RulesBuilder;
+}
+
+export interface AccessControlModuleAsyncOptions extends Pick<ModuleMetadata, 'imports'> {
+  name?: string;
+  useExisting?: Type<AccessControlOptionsFactory>;
+  useClass?: Type<RulesBuilder>;
+  useFactory?: (...args: any[]) => Promise<RulesBuilder> | RulesBuilder;
+  inject?: Injection;
+}
 
 @Global()
 @Module({})
 export class AccessControlModule {
-    public static forRules(rules: RulesBuilder, options?: ACOptions): DynamicModule {
-        let controllers = [];
+  public static forRules(rules: RulesBuilder, options?: ACOptions): DynamicModule {
+    let controllers = [];
 
-        if (options) {
-            Reflect.defineMetadata(PATH_METADATA, options.grantsEndpoint, GrantsController);
-            controllers = [...(options.grantsEndpoint ? [GrantsController] : [])];
-        }
-
-        return {
-            module: AccessControlModule,
-            controllers: [...controllers],
-            providers: [
-                {
-                    provide: RULES_BUILDER_TOKEN,
-                    useValue: rules,
-                },
-            ],
-            exports: [
-                {
-                    provide: RULES_BUILDER_TOKEN,
-                    useValue: rules,
-                },
-            ],
-        };
+    if (options) {
+      Reflect.defineMetadata(PATH_METADATA, options.grantsEndpoint, GrantsController);
+      controllers = [...(options.grantsEndpoint ? [GrantsController] : [])];
     }
 
-    public static forRootAsync(options: { inject?: Injection; useFactory: (...args: any) => RulesBuilder | Promise<RulesBuilder> }): DynamicModule {
-        const provider = {
-            provide: RULES_BUILDER_TOKEN,
-            useFactory: options.useFactory,
-            inject: options.inject || [],
-        };
+    return {
+      module: AccessControlModule,
+      controllers: [...controllers],
+      providers: [
+        {
+          provide: RULES_BUILDER_TOKEN,
+          useValue: rules,
+        },
+      ],
+      exports: [
+        {
+          provide: RULES_BUILDER_TOKEN,
+          useValue: rules,
+        },
+      ],
+    };
+  }
 
-        return {
-            module: AccessControlModule,
-            providers: [provider],
-            exports: [provider],
-        };
+  public static forRootAsync(options: AccessControlModuleAsyncOptions): DynamicModule {
+    const { inject = [], imports = [], useFactory, useExisting, useClass } = options;
+    let provider: Provider<RulesBuilder | Promise<RulesBuilder>> = {
+      provide: RULES_BUILDER_TOKEN,
+      useFactory,
+      inject,
+    };
+
+    if (useExisting) {
+      provider = { ...provider, useExisting };
+    } else if (useClass) {
+      provider = { ...provider, useClass };
     }
+
+    return {
+      module: AccessControlModule,
+      imports,
+      providers: [provider],
+      exports: [provider],
+    };
+  }
 }


### PR DESCRIPTION
Hey! Here's a small improvement PR

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Improve typings of ACL module and allow to import modules and allow to provide a class of RulesBuilder.

* **What is the current behavior?** (You can also link to an open issue here)

Needed to make a module global in order to inject it to the factory that provides the RuleBuilder

* **What is the new behavior (if this is a feature change)?**

Now you can import a specific module and inject one of its services for access-control-module.

